### PR TITLE
Enable Building on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,14 +116,20 @@ src/TwoViewReconstruction.cc)
 
 add_subdirectory(Thirdparty/g2o)
 
+if(APPLE)
+set(DBOW2_LIBS ${PROJECT_SOURCE_DIR}/Thirdparty/DBoW2/lib/libDBoW2.dylib)
+set(G2O_LIBS ${PROJECT_SOURCE_DIR}/Thirdparty/g2o/lib/libg2o.dylib)
+else()
+set(DBOW2_LIBS ${PROJECT_SOURCE_DIR}/Thirdparty/DBoW2/lib/libDBoW2.so)
+set(G2O_LIBS ${PROJECT_SOURCE_DIR}/Thirdparty/g2o/lib/libg2o.so)
+endif()
+
 target_link_libraries(${PROJECT_NAME}
 ${OpenCV_LIBS}
 ${EIGEN3_LIBS}
 ${Pangolin_LIBRARIES}
-${PROJECT_SOURCE_DIR}/Thirdparty/DBoW2/lib/libDBoW2.so
-${PROJECT_SOURCE_DIR}/Thirdparty/g2o/lib/libg2o.so
--lboost_serialization
--lcrypto
+${DBOW2_LIBS}
+${G2O_LIBS}
 )
 
 

--- a/Examples/Stereo-Inertial/stereo_inertial_euroc.cc
+++ b/Examples/Stereo-Inertial/stereo_inertial_euroc.cc
@@ -164,6 +164,10 @@ int main(int argc, char **argv)
     cv::Mat imLeft, imRight, imLeftRect, imRightRect;
     for (seq = 0; seq<num_seq; seq++)
     {
+    #if defined(__APPLE__)
+        // Moving main loop to a separate thread so that we could run UI thread on the main thread.
+        std::thread runthread([&]() {  // Start in new thread
+    #endif
         // Seq loop
         vector<ORB_SLAM3::IMU::Point> vImuMeas;
         double t_rect = 0;
@@ -255,7 +259,15 @@ int main(int argc, char **argv)
 
             SLAM.ChangeDataset();
         }
+    #if defined(__APPLE__)
+        // stop viewer so that we could exit UI / main thread
+        SLAM.StopViewer();
+        });
 
+        // OSX requires calling visualization on main thread
+        SLAM.StartViewer();
+        runthread.join();
+    #endif
 
     }
     // Stop all threads

--- a/Examples/Stereo/stereo_euroc.cc
+++ b/Examples/Stereo/stereo_euroc.cc
@@ -133,6 +133,10 @@ int main(int argc, char **argv)
     {
 
         // Seq loop
+    #if defined(__APPLE__)
+        // Moving main loop to a separate thread so that we could run UI thread on the main thread.
+        std::thread runthread([&]() {  // Start in new thread
+    #endif
 
         double t_rect = 0;
         int num_rect = 0;
@@ -212,6 +216,16 @@ int main(int argc, char **argv)
 
             SLAM.ChangeDataset();
         }
+
+    #if defined(__APPLE__)
+        // stop viewer so that we could exit UI / main thread
+        SLAM.StopViewer();
+        });
+
+        // OSX requires calling visualization on main thread
+        SLAM.StartViewer();
+        runthread.join();
+    #endif
 
     }
     // Stop all threads

--- a/Thirdparty/DBoW2/DBoW2/FORB.cpp
+++ b/Thirdparty/DBoW2/DBoW2/FORB.cpp
@@ -13,7 +13,11 @@
 #include <vector>
 #include <string>
 #include <sstream>
+#ifdef __APPLE__
+#include <stdint.h>
+#else
 #include <stdint-gcc.h>
+#endif
 
 #include "FORB.h"
 

--- a/Thirdparty/g2o/g2o/core/estimate_propagator.h
+++ b/Thirdparty/g2o/g2o/core/estimate_propagator.h
@@ -34,7 +34,7 @@
 #include <set>
 #include <limits>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__APPLE__)
 #include <unordered_map>
 #else
 #include <tr1/unordered_map>
@@ -135,7 +135,11 @@ namespace g2o {
           size_t operator ()(const OptimizableGraph::Vertex* v) const { return v->id();}
       };
 
+      #if defined(_MSC_VER) || defined(__APPLE__)
+      typedef std::unordered_map<OptimizableGraph::Vertex*, AdjacencyMapEntry, VertexIDHashFunction> AdjacencyMap;
+      #else
       typedef std::tr1::unordered_map<OptimizableGraph::Vertex*, AdjacencyMapEntry, VertexIDHashFunction> AdjacencyMap;
+      #endif
 
     public:
       EstimatePropagator(OptimizableGraph* g);

--- a/Thirdparty/g2o/g2o/core/hyper_graph.h
+++ b/Thirdparty/g2o/g2o/core/hyper_graph.h
@@ -35,7 +35,7 @@
 #include <limits>
 #include <cstddef>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__APPLE__)
 #include <unordered_map>
 #else
 #include <tr1/unordered_map>
@@ -90,7 +90,11 @@ namespace g2o {
       typedef std::set<Edge*>                           EdgeSet;
       typedef std::set<Vertex*>                         VertexSet;
 
+      #if defined(_MSC_VER) || defined(__APPLE__)
+      typedef std::unordered_map<int, Vertex*>          VertexIDMap;
+      #else
       typedef std::tr1::unordered_map<int, Vertex*>     VertexIDMap;
+      #endif
       typedef std::vector<Vertex*>                      VertexContainer;
 
       //! abstract Vertex, your types must derive from that one

--- a/Thirdparty/g2o/g2o/core/marginal_covariance_cholesky.h
+++ b/Thirdparty/g2o/g2o/core/marginal_covariance_cholesky.h
@@ -33,7 +33,7 @@
 #include <cassert>
 #include <vector>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__APPLE__)
 #include <unordered_map>
 #else
 #include <tr1/unordered_map>
@@ -50,7 +50,11 @@ namespace g2o {
       /**
        * hash struct for storing the matrix elements needed to compute the covariance
        */
+      #if defined(_MSC_VER) || defined(__APPLE__)
+      typedef std::unordered_map<int, double>          LookupMap;
+      #else
       typedef std::tr1::unordered_map<int, double>     LookupMap;
+      #endif
     
     public:
       MarginalCovarianceCholesky();

--- a/Thirdparty/g2o/g2o/core/robust_kernel.h
+++ b/Thirdparty/g2o/g2o/core/robust_kernel.h
@@ -27,7 +27,7 @@
 #ifndef G2O_ROBUST_KERNEL_H
 #define G2O_ROBUST_KERNEL_H
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__APPLE__)
 #include <memory>
 #else
 #include <tr1/memory>
@@ -74,7 +74,11 @@ namespace g2o {
     protected:
       double _delta;
   };
+  #if defined(_MSC_VER) || defined(__APPLE__)
+  typedef std::shared_ptr<RobustKernel> RobustKernelPtr;
+  #else
   typedef std::tr1::shared_ptr<RobustKernel> RobustKernelPtr;
+  #endif
 
 } // end namespace g2o
 

--- a/Thirdparty/g2o/g2o/core/sparse_block_matrix_ccs.h
+++ b/Thirdparty/g2o/g2o/core/sparse_block_matrix_ccs.h
@@ -34,7 +34,7 @@
 #include "../../config.h"
 #include "matrix_operations.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__APPLE__)
 #include <unordered_map>
 #else
 #include <tr1/unordered_map>
@@ -223,7 +223,11 @@ namespace g2o {
       //! rows of the matrix
       int rows() const {return _rowBlockIndices.size() ? _rowBlockIndices.back() : 0;}
 
+      #if defined(_MSC_VER) || defined(__APPLE__)
+      typedef std::unordered_map<int, MatrixType*> SparseColumn;
+      #else
       typedef std::tr1::unordered_map<int, MatrixType*> SparseColumn;
+      #endif
 
       SparseBlockMatrixHashMap(const std::vector<int>& rowIndices, const std::vector<int>& colIndices) :
         _rowBlockIndices(rowIndices), _colBlockIndices(colIndices)

--- a/evaluation/associate.py
+++ b/evaluation/associate.py
@@ -85,8 +85,8 @@ def associate(first_list, second_list,offset,max_difference):
     matches -- list of matched tuples ((stamp1,data1),(stamp2,data2))
     
     """
-    first_keys = first_list.keys()
-    second_keys = second_list.keys()
+    first_keys = list(first_list)
+    second_keys = list(second_list)
     potential_matches = [(abs(a - (b + offset)), a, b) 
                          for a in first_keys 
                          for b in second_keys 

--- a/evaluation/evaluate_ate_scale.py
+++ b/evaluation/evaluate_ate_scale.py
@@ -40,7 +40,7 @@
 This script computes the absolute trajectory error from the ground truth
 trajectory and the estimated trajectory.
 """
-
+from __future__ import print_function
 import sys
 import numpy
 import argparse
@@ -78,7 +78,7 @@ def align(model,data):
     norms = 0.0
 
     for column in range(data_zerocentered.shape[1]):
-	dots += numpy.dot(data_zerocentered[:,column].transpose(),rotmodel[:,column])
+        dots += numpy.dot(data_zerocentered[:,column].transpose(),rotmodel[:,column])
         normi = numpy.linalg.norm(model_zerocentered[:,column])
         norms += normi*normi
 
@@ -164,34 +164,34 @@ if __name__=="__main__":
     second_xyz_aligned = scale * rot * second_xyz + trans
     second_xyz_notscaled = rot * second_xyz + trans
     second_xyz_notscaled_full = rot * second_xyz_full + trans
-    first_stamps = first_list.keys()
+    first_stamps = list(first_list)
     first_stamps.sort()
     first_xyz_full = numpy.matrix([[float(value) for value in first_list[b][0:3]] for b in first_stamps]).transpose()
     
-    second_stamps = second_list.keys()
+    second_stamps = list(second_list)
     second_stamps.sort()
     second_xyz_full = numpy.matrix([[float(value)*float(args.scale) for value in second_list[b][0:3]] for b in second_stamps]).transpose()
     second_xyz_full_aligned = scale * rot * second_xyz_full + trans
     
     if args.verbose:
-        print "compared_pose_pairs %d pairs"%(len(trans_error))
+        print("compared_pose_pairs %d pairs"%(len(trans_error)))
 
-        print "absolute_translational_error.rmse %f m"%numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error))
-        print "absolute_translational_error.mean %f m"%numpy.mean(trans_error)
-        print "absolute_translational_error.median %f m"%numpy.median(trans_error)
-        print "absolute_translational_error.std %f m"%numpy.std(trans_error)
-        print "absolute_translational_error.min %f m"%numpy.min(trans_error)
-        print "absolute_translational_error.max %f m"%numpy.max(trans_error)
-        print "max idx: %i" %numpy.argmax(trans_error)
+        print("absolute_translational_error.rmse %f m"%numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error)))
+        print("absolute_translational_error.mean %f m"%numpy.mean(trans_error))
+        print("absolute_translational_error.median %f m"%numpy.median(trans_error))
+        print("absolute_translational_error.std %f m"%numpy.std(trans_error))
+        print("absolute_translational_error.min %f m"%numpy.min(trans_error))
+        print("absolute_translational_error.max %f m"%numpy.max(trans_error))
+        print("max idx: %i" %numpy.argmax(trans_error))
     else:
-        # print "%f, %f " % (numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error)),  scale)
-        # print "%f,%f" % (numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error)),  scale)
-        print "%f,%f,%f" % (numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error)), scale, numpy.sqrt(numpy.dot(trans_errorGT,trans_errorGT) / len(trans_errorGT)))
-        # print "%f" % len(trans_error)
+        # print("%f, %f " % (numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error)),  scale))
+        # print("%f,%f" % (numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error)),  scale))
+        print("%f,%f,%f" % (numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error)), scale, numpy.sqrt(numpy.dot(trans_errorGT,trans_errorGT) / len(trans_errorGT))))
+        # print("%f" % len(trans_error))
     if args.verbose2:
-        print "compared_pose_pairs %d pairs"%(len(trans_error))
-        print "absolute_translational_error.rmse %f m"%numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error))
-        print "absolute_translational_errorGT.rmse %f m"%numpy.sqrt(numpy.dot(trans_errorGT,trans_errorGT) / len(trans_errorGT))
+        print("compared_pose_pairs %d pairs"%(len(trans_error)))
+        print("absolute_translational_error.rmse %f m"%numpy.sqrt(numpy.dot(trans_error,trans_error) / len(trans_error)))
+        print("absolute_translational_errorGT.rmse %f m"%numpy.sqrt(numpy.dot(trans_errorGT,trans_errorGT) / len(trans_errorGT)))
 
     if args.save_associations:
         file = open(args.save_associations,"w")

--- a/include/LoopClosing.h
+++ b/include/LoopClosing.h
@@ -48,7 +48,7 @@ public:
 
     typedef pair<set<KeyFrame*>,int> ConsistentGroup;    
     typedef map<KeyFrame*,g2o::Sim3,std::less<KeyFrame*>,
-        Eigen::aligned_allocator<std::pair<const KeyFrame*, g2o::Sim3> > > KeyFrameAndPose;
+        Eigen::aligned_allocator<std::pair<KeyFrame*const,g2o::Sim3> > > KeyFrameAndPose;
 
 public:
 

--- a/include/System.h
+++ b/include/System.h
@@ -179,6 +179,9 @@ public:
 
     //void SaveAtlas(int type);
 
+    void StartViewer();
+    void StopViewer();
+
 private:
 
     //bool LoadAtlas(string filename, int type);

--- a/src/ORBmatcher.cc
+++ b/src/ORBmatcher.cc
@@ -26,7 +26,11 @@
 
 #include "Thirdparty/DBoW2/DBoW2/FeatureVector.h"
 
+#if defined(__APPLE__)
+#include<stdint.h>
+#else
 #include<stdint-gcc.h>
+#endif
 
 using namespace std;
 

--- a/src/System.cc
+++ b/src/System.cc
@@ -23,7 +23,9 @@
 #include <thread>
 #include <pangolin/pangolin.h>
 #include <iomanip>
+#if not defined(__APPLE__)
 #include <openssl/md5.h>
+#endif
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/string.hpp>
 #include <boost/archive/text_iarchive.hpp>


### PR DESCRIPTION
- Added Apple specific checks to CMakeLists and source code
- Fixed build issue related to LoopClosing.h KeyFrameAndPose definition
- Removed --lboost_serialization from CMakeLists
- Removed --lcrypto from CMakeLists
- Tested using OSX 10.15.5. Build passes and euroc_examples.sh appears
to be working.

Notes:
I also had issues finding openssl/md5.h header on OSX even after installing openssl using Homebrew. https://superuser.com/questions/1034164/missing-md5-h-header-as-i-install-cmusfm-scrobbler-for-cmus-on-os-x provided detailed solutions.