### PR TITLE
Added ready-to-use Docker images for Realsense Cameras

### DIFF
--- a/Docker/Makefile
+++ b/Docker/Makefile
@@ -1,0 +1,37 @@
+REALSENSE_DIRECTORY=realsense-container/
+REALSENSE_IM_NAME=lmwafer/realsense-ready
+REALSENSE_IM_TAG=2.0-ubuntu18.04
+REALSENSE_CONT_NAME=realsense-container
+
+ORB_DIRECTORY=orb-container/
+ORB_IM_NAME=lmwafer/orb-slam-3-ready
+ORB_IM_TAG=1.0-ubuntu18.04
+ORB_CONT_NAME=orb-3-container # You will need to apply the exact same name to container_name in orb-container/docker-compose.yml
+
+default: up-orb enter-orb
+
+
+up-orb:
+	sudo xhost +local:root && cd ${ORB_DIRECTORY} && sudo docker-compose up -d
+
+enter-orb:
+	clear && docker exec -it ${ORB_CONT_NAME} bash
+
+down-orb:
+	cd ${ORB_DIRECTORY} && docker-compose down
+
+build-orb:
+	cd ${ORB_DIRECTORY} && sudo docker build -t ${ORB_IM_NAME}:${ORB_IM_TAG} .
+
+
+up-realsense:
+	sudo xhost +local:root && cd ${REALSENSE_DIRECTORY} && sudo docker-compose up -d
+
+enter-realsense:
+	clear && docker exec -it ${REALSENSE_CONT_NAME} bash
+
+down-realsense:
+	cd ${REALSENSE_DIRECTORY} && docker-compose down
+
+build-realsense:
+	cd ${REALSENSE_DIRECTORY} && sudo docker build -t ${REALSENSE_IM_NAME}:${REALSENSE_READY_IM_TAG} .

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,101 @@
+# **ORB-SLAM 3** image
+
+This images contains a pre-installed ORB-SLAM 3 in */dpds/ORB_SLAM3*. See on Docker Hub [lmwafer/orb-slam-3-ready](https://hub.docker.com/r/lmwafer/orb-slam-3-ready). 
+
+It is based on Docker image realsense-ready to use Intel RealSense 2 SDK and cameras. See on Docker Hub [lmwafer/realsense-ready](https://hub.docker.com/r/lmwafer/realsense-ready/tags). 
+
+## Image prerequisites
+
+- Docker (tested with Docker 20.10.7), see [Install Docker Engine](https://docs.docker.com/engine/install/)
+
+- Docker Compose (tested with Docker Compose 1.29.2), see [Install Docker Compose](https://docs.docker.com/compose/install/)
+  You may have a `/usr/local/bin/docker-compose: no such file or directory` error. In this case, use
+  ```bash
+  sudo mkdir /usr/local/bin/docker-compose
+  ```
+  before restarting the installation process
+
+- Nvidia Container Toolkit (tested with ubuntu20.04 distribution), see [NVIDIA Container Toolkit Installation Guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+
+- The `device id` parameter in **orb-slam/docker-compose.yml** may take another number on different machines. Use
+  ```bash
+  lshw -c display
+  ```
+  to get the id of your GPU. See [Enabling GPU access with Compose](https://docs.docker.com/compose/gpu-support/)
+
+## Image installation
+
+The tag may be outdated. See on [Dockerhub](https://hub.docker.com/r/lmwafer/orb-slam-3-ready/tags).
+
+```bash
+docker pull lmwafer/orb-slam-3-ready:1.0-ubuntu18.04
+```
+
+## Image usage
+
+All the commands need to be run in **Docker** directory. 
+
+Get inside a freshly new container (basically `up` + `enter`)
+```bash
+make
+```
+
+Start an *orb-3-container* (uses **orb-container/docker-compose.yml**)
+```bash
+make up-orb
+```
+
+Enter running *orb-3-container*
+```bash
+make enter-orb
+```
+
+Stop running *orb-3-container* (and removes it, add a *rw* volume in *docker-compose.yml* to save data)
+```bash
+make down-orb
+```
+
+Build *orb-slam-3-ready* image (uses **orb-container/Dockerfile**)
+```bash
+make build-orb
+```
+
+# **Realsense** image
+
+This images contains a pre-installed Intel Realsense 2 SDK in */dpds/librealsense-2.50.0*. See on Docker Hub [lmwafer/realsense-ready](https://hub.docker.com/r/lmwafer/realsense-ready). 
+
+## Image prerequisites
+
+Nothing except an Internet connexion and a GPU !
+
+## Image installation
+
+The tag may be outdated. See on [Dockerhub](https://hub.docker.com/r/lmwafer/realsense-ready/tags).
+
+```bash
+docker pull lmwafer/realsense-ready:2.0-ubuntu18.04
+```
+
+## Image usage
+
+All the commands need to be run in **Docker** directory. 
+
+Start a container (uses **realsense-container/docker-compose.yml**)
+```bash
+make up-realsense
+```
+
+Enter running *realsense-container*
+```bash
+make enter-realsense
+```
+
+Stop running *realsense-container* (and removes it, add a *rw* volume in *docker-compose.yml* to save data)
+```bash
+make down-realsense
+```
+
+Build realsense-ready image (uses **realsense-container/Dockerfile**)
+```bash
+make build-realsense
+```

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -95,7 +95,7 @@ Stop running *realsense-container* (and removes it, add a *rw* volume in *docker
 make down-realsense
 ```
 
-Build realsense-ready image (uses **realsense-container/Dockerfile**)
+Build *realsense-ready* image (uses **realsense-container/Dockerfile**)
 ```bash
 make build-realsense
 ```

--- a/Docker/orb-container/Dockerfile
+++ b/Docker/orb-container/Dockerfile
@@ -1,0 +1,150 @@
+# This is a Docker file to build a Docker image with ORB-SLAM 3 and all its dependencies pre-installed
+# For more info about ORB-SLAM 3 dependencies go check https://github.com/UZ-SLAMLab/ORB_SLAM3
+FROM lmwafer/realsense-ready:2.0-ubuntu18.04
+
+    #-[] Install dependencies
+RUN apt-get update && \
+    apt-get -y upgrade && \
+
+    #-> Install general usage dependencies
+    echo "Installing general usage dependencies ..." && \
+    apt-get install -y apt-file && \
+    apt-file update && \
+    apt-get install -y nano \
+    pkg-config && \
+
+    #-> Install OpenCV dependencies
+    #-? From : http://techawarey.com/programming/install-opencv-c-c-in-ubuntu-18-04-lts-step-by-step-guide/
+    echo "Installing OpenCV dependencies ..." && \
+    apt-get install -y\
+    libgtk2.0-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    software-properties-common && \
+
+    #-> Install Pangolin dependencies
+    #-? From : https://cdmana.com/2021/02/20210204202321078t.html
+    echo "Installing Pangolin dependencies ..." && \
+    apt-get install -y \
+    libglew-dev \
+    libboost-dev \
+    libboost-thread-dev \
+    libboost-filesystem-dev \
+    ffmpeg \
+    libavutil-dev \
+    libpng-dev && \
+
+    #-> Install Eigen 3 last version
+    #-? Needs to be installed BEFORE Pangolin as it also needs Eigen
+    #-> Linear algebra library
+    echo "Installing Eigen 3 last version ..." && \
+    apt-get install -y libeigen3-dev && \
+   
+    #-> Install Pangolin last version
+    #-? 3D Vizualisation tool
+    #-? From : https://cdmana.com/2021/02/20210204202321078t.html
+    echo "Installing Pangolin last version ..." && \
+    cd /dpds/ && \
+    git clone https://github.com/stevenlovegrove/Pangolin.git Pangolin && \
+    cd /dpds/Pangolin/ && \
+    mkdir build && \
+    cd build/ && \
+    cmake -D CMAKE_BUILD_TYPE=RELEASE \
+    -DCPP11_NO_BOOST=1 \
+    /dpds/Pangolin/ && \
+    make -j4 && \
+    make install
+
+    #-[] Install OpenCV last version
+    #-? From : http://techawarey.com/programming/install-opencv-c-c-in-ubuntu-18-04-lts-step-by-step-guide/
+    #-? Another RUN command in order to free memory
+    #-? Usual computer vision library
+RUN echo "Installing OpenCV last version ..." && \
+    cd /dpds/ && \
+    git clone https://github.com/Itseez/opencv.git opencv && \
+    git clone https://github.com/Itseez/opencv_contrib.git opencv_contrib && \
+    cd opencv/ && \
+    mkdir build && \
+    cd build/ && \
+    cmake -D CMAKE_BUILD_TYPE=RELEASE \
+    -D BUILD_TIFF=ON \
+    -D WITH_CUDA=OFF \
+    -D ENABLE_AVX=OFF \
+    -D WITH_OPENGL=OFF \
+    -D WITH_OPENCL=OFF \
+    -D WITH_IPP=OFF \
+    -D WITH_TBB=ON \
+    -D BUILD_TBB=ON \
+    -D WITH_EIGEN=ON \
+    -D WITH_V4L=OFF \
+    -D WITH_VTK=OFF \
+    -D BUILD_TESTS=OFF \
+    -D BUILD_PERF_TESTS=OFF \
+    -D OPENCV_GENERATE_PKGCONFIG=ON \
+    -D OPENCV_EXTRA_MODULES_PATH=/dpds/opencv_contrib/modules \
+    /dpds/opencv/ && \
+    make -j4 && \
+    make install && \
+    ldconfig
+    
+    #-> Get ORB-SLAM 3 installation ready
+    #-? From : https://github.com/UZ-SLAMLab/ORB_SLAM3
+    #-? Another RUN command in order to free memory
+RUN echo "Getting ORB-SLAM 3 installation ready ..." && \
+    cd /dpds/ && \
+    git clone https://github.com/UZ-SLAMLab/ORB_SLAM3.git ORB_SLAM3 && \
+    
+    #-! From here, a compilation method is proposed by the repo: "chmod +x build.sh && ./build.sh"
+    #-! Such method remove some control over the image build (simultaneous jobs number, directories, OpenCV version etc.) 
+    #-! Thus evey step in build.sh has been added here
+
+    #-> Install DBoW2
+    #-? Images to bag-of-word library
+    echo "Installing 'built-in' DBoW2 ..." && \
+    cd /dpds/ORB_SLAM3/ && \
+    cd /dpds/ORB_SLAM3/Thirdparty/DBoW2/ && \
+    mkdir build && \
+    cd build/ && \
+    cmake -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/ \
+    /dpds/ORB_SLAM3/Thirdparty/DBoW2/ && \
+    make -j4 && \
+
+    #-> Install g2o
+    #-? Graph optimization
+    echo "Installing 'built-in' g2o ..." && \
+    cd /dpds/ORB_SLAM3/Thirdparty/g2o/ && \
+    mkdir build && \
+    cd build/ && \
+    cmake -D CMAKE_BUILD_TYPE=Release \
+    /dpds/ORB_SLAM3/Thirdparty/g2o/ && \
+    make -j4 && \
+
+    #-> Install Sophus
+    #-? Lie groups library
+    echo "Configuring and building Thirdparty/Sophus ..." && \
+    cd /dpds/ORB_SLAM3/Thirdparty/Sophus/ && \
+    mkdir build && \
+    cd build/ && \
+    cmake -D CMAKE_BUILD_TYPE=Release \
+    /dpds/ORB_SLAM3/Thirdparty/Sophus/ && \
+    make -j4 && \
+
+    #-> Uncompress vocabulary
+    #-? ORB-SLAM 3 useful data
+    echo "Uncompressing vocabulary ..." && \
+    cd /dpds/ORB_SLAM3/ && \
+    cd Vocabulary && \
+    tar -xf ORBvoc.txt.tar.gz
+    
+    #-> Install ORB-SLAM 3
+    #-? Another RUN command in order to free memory
+RUN echo "Configuring and building ORB_SLAM3 ..." && \
+    cd /dpds/ORB_SLAM3 && \
+    mkdir build && \
+    cd build/ && \
+    cmake -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/ \
+    /dpds/ORB_SLAM3 && \
+    make -j4

--- a/Docker/orb-container/docker-compose.yml
+++ b/Docker/orb-container/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.7'
+
+services:
+  realsense-ready:
+    container_name: orb-3-container
+    image: lmwafer/orb-slam-3-ready:1.0-ubuntu18.04
+    restart: always
+    privileged: true
+    ports:
+      - "8087:8087"                       # Inherited from realsense-ready
+    environment:
+      - DISPLAY=$DISPLAY                  # Inherited from realsense-ready
+      - QT_X11_NO_MITSHM=1                # Inherited from realsense-ready
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix     # For orb-ready only, give access to X11
+      - /dev:/dev:ro
+    stdin_open: true                      # For orb-ready only, equivalent to "docker run -i"
+    tty: true                             # For orb-ready only, equivalent to "docker run -t"
+
+    deploy:                               # For orb-ready only, in response to what(): Pangolin X11: Failed to create an OpenGL context
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            device_ids: ['0']             # This ID may change on different machines : `lshw -c display` for more info
+            capabilities: [gpu]

--- a/Docker/realsense-container/Dockerfile
+++ b/Docker/realsense-container/Dockerfile
@@ -1,0 +1,55 @@
+# This is a Docker file to build a Docker image with Intel Realsense 2 SDK and all its dependencies pre-installed
+# For more info about ORB-SLAM 3 dependencies go check https://github.com/IntelRealSense/librealsense
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+
+    #-> Install general usage dependencies
+    echo "Installing general usage dependencies ..." && \
+    apt-get install -y \
+    git \
+    cmake \
+    wget \
+    tar \
+    libx11-dev \
+    xorg-dev \
+    libssl-dev \
+    build-essential \
+    libusb-1.0-0-dev \
+    libglu1-mesa-dev && \
+    
+    #-> Install OpenGL
+    #-? Vizualisation tool
+    echo "Installing OpenGL ..." && \
+    apt-get install -qq --no-install-recommends \
+    libglvnd0 \
+    libgl1 \
+    libglx0 \
+    libegl1 \
+    libxext6 \
+    libx11-6 && \
+    rm -rf /var/lib/apt/lists/* && \
+
+    #-> Get folder ready
+    #-? /app for the containerized application and /dpds for dependencies
+    mkdir /app /dpds && \
+
+    #-> Install Realsense SDK
+    echo "Installing Realsense SDK ..." && \
+    cd dpds && \
+    wget --no-check-certificate https://github.com/IntelRealSense/librealsense/archive/refs/tags/v2.50.0.tar.gz && \
+    tar -xzf v2.50.0.tar.gz && \
+    rm v2.50.0.tar.gz && \
+    cd librealsense-2.50.0/ && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make && \
+    make install
+
+#-> Set environment variables
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES graphics,utility,compute
+
+#-> Update the packages to get things ready
+RUN apt-get update

--- a/Docker/realsense-container/docker-compose.yml
+++ b/Docker/realsense-container/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.7'
+
+services:
+  realsense-ready:
+    container_name: realsense-container
+    image: lmwafer/realsense-ready:2.0-ubuntu18.04
+    restart: always
+    privileged: true
+    ports:
+      - "8084:8084"
+    environment:
+      - DISPLAY=$DISPLAY                  # Give access to display
+      - QT_X11_NO_MITSHM=1
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix     # Give access to X11
+      - /dev:/dev:ro
+    stdin_open: true                      # Equivalent to "docker run -i"
+    tty: true                             # Equivalent to "docker run -t"
+
+    deploy:                               # In response to libGL error: No matching fbConfigs or visuals found
+      resources:                          #                libGL error: failed to load driver: swrast
+        reservations:                     #                Could not open OpenGL window, please check your graphic drivers or use the textual SDK tools
+          devices:
+          - driver: nvidia
+            device_ids: ['0']             # This ID may change on different machines : `lshw -c display` for more info
+            capabilities: [gpu]

--- a/README.md
+++ b/README.md
@@ -151,7 +151,31 @@ Execute the following script to process sequences and compute the RMS ATE:
 ./tum_vi_eval_examples
 ```
 
-# 7. ROS Examples
+# 7. Running ORB-SLAM inside Docker container
+Examples using Intel Realsense cameras can be runned inside a Docker container. The image has ORB-SLAM 3 and all dependencies installed in its */dpds* directory. 
+
+## Basic mode
+1. This will pull the image from [Docker hub](https://hub.docker.com/r/lmwafer/orb-slam-3-ready/tags) and run a container (needs a GPU for Pangolin) (container removed after exit)
+```bash
+docker run --privileged --name orb-3-container --rm -p 8087:8087 -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev:/dev:ro --gpus all -it lmwafer/orb-slam-3-ready:1.0-ubuntu18.04
+```
+2. Inside the container run this to reach 'ORB_SLAM3' directory
+```bash
+cd /dpds/ORB_SLAM3/
+```
+You can run every example presented above with Realsense cameras. Everything in the image is already built !
+## Advanced mode
+The image used is based on three image layers : [Ubuntu 18.04](https://hub.docker.com/_/ubuntu?tab=tags&page=1&name=18.04), [realsense-ready](https://hub.docker.com/r/lmwafer/realsense-ready) and [orb-slam-3-ready](https://hub.docker.com/r/lmwafer/orb-slam-3-ready). You may want a better control on what's inside them. To this matter *Docker* directory contains : 
+
+- *Dockerfile* for both realsense and orb images. Note that **orb-slam-3-ready** lays on top of **realsense-ready**. Modify that by changing `FORM` instruction in *Dockerfile-orb*. Don't forget general usage dependencies that came along realsense-ready image !
+
+- *docker-compose.yml* to start both containers separately. Files are almost identical, this is for Kubernetes-like deployement
+
+- *README.md* documentation file
+
+- *Makefile* to provide usual commands
+
+# 8. ROS Examples
 
 ### Building the nodes for mono, mono-inertial, stereo, stereo-inertial and RGB-D
 Tested with ROS Melodic and ubuntu 18.04.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Examples using Intel Realsense cameras can be runned inside a Docker container. 
 ## Basic mode
 1. This will pull the image from [Docker hub](https://hub.docker.com/r/lmwafer/orb-slam-3-ready/tags) and run a container (needs a GPU for Pangolin) (container removed after exit)
 ```bash
-docker run --privileged --name orb-3-container --rm -p 8087:8087 -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev:/dev:ro --gpus all -it lmwafer/orb-slam-3-ready:1.0-ubuntu18.04
+sudo xhost +local:root && docker run --privileged --name orb-3-container --rm -p 8087:8087 -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev:/dev:ro --gpus all -it lmwafer/orb-slam-3-ready:1.0-ubuntu18.04
 ```
 2. Inside the container run this to reach 'ORB_SLAM3' directory
 ```bash


### PR DESCRIPTION
Two Docker images : **orb-slam-3-ready** and  **realsense-ready**.  Both work on Ubuntu 20.04 and provide a 18.04 environment with everything installed. 

The ORB one is based on the RS one but build files are provided in order to allow total control on what users want to have. 
*Dockerfile*, *docker-compose.yml*, usual commands and documentation are included. 