### PR TITLE
Solving an error on ubuntu 20.04 and 18.04 by adding a line before CMakeLists.txt file 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_compile_options(-std=c++14)
 cmake_minimum_required(VERSION 2.8)
 project(ORB_SLAM3)
 


### PR DESCRIPTION
This error may occur on Ubuntu 20.04 and 18.04.

When running `./build.sh`, I got
```
make[2]: *** [CMakeFiles/ORB_SLAM3.dir/build.make:76: CMakeFiles/ORB_SLAM3.dir/src/Tracking.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:711: CMakeFiles/ORB_SLAM3.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```
The problem can be solved by add `add_compile_options(-std=c++14)` before CMakeLists.txt file.
Then it build successfully.

Same solving method for the error:
```
make[2]: *** [CMakeFiles/ORB_SLAM3.dir/build.make:375：CMakeFiles/ORB_SLAM3.dir/src/MLPnPsolver.cpp.o] Error 1
make[2]: *** [CMakeFiles/ORB_SLAM3.dir/build.make:76：CMakeFiles/ORB_SLAM3.dir/src/Tracking.cc.o] Error 1
make[2]: *** [CMakeFiles/ORB_SLAM3.dir/build.make:245：CMakeFiles/ORB_SLAM3.dir/src/Frame.cc.o] Error 1
make[2]: *** [CMakeFiles/ORB_SLAM3.dir/build.make:102：CMakeFiles/ORB_SLAM3.dir/src/LoopClosing.cc.o] Error 1
make[2]: *** [CMakeFiles/ORB_SLAM3.dir/build.make:323：CMakeFiles/ORB_SLAM3.dir/src/G2oTypes.cc.o] Error 1
make[2]: *** [CMakeFiles/ORB_SLAM3.dir/build.make:232：CMakeFiles/ORB_SLAM3.dir/src/Optimizer.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:390：CMakeFiles/ORB_SLAM3.dir/all] Error 2
make: *** [Makefile:84：all] Error 2
```