### PR TITLE
Update mono_euroc.cc, make it show the view windows

### DIFF
--- a/Examples/Monocular/mono_euroc.cc
+++ b/Examples/Monocular/mono_euroc.cc
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
     int fps = 20;
     float dT = 1.f/fps;
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::MONOCULAR, false);
+    ORB_SLAM3::System SLAM(argv[1],argv[2],ORB_SLAM3::System::MONOCULAR, true);
     float imageScale = SLAM.GetImageScale();
 
     double t_resize = 0.f;


### PR DESCRIPTION
Only change `false` to `true`. 
I don't understand why the default setting is `doesn't show the view windows`. In that case, people only got `one map created` in command line, and then nothing happened. It is hard for a novice (at least for me) to figure out what's wrong when he first run ORBSLAM. For coincidence, the EuRoC Monocular is the most frequently used setting for novice. 
Hope it can help beginners.